### PR TITLE
Fixed issue with missing dependencies

### DIFF
--- a/src/cesium_ion.rb
+++ b/src/cesium_ion.rb
@@ -3,7 +3,13 @@ require "extensions.rb"
 
 module Cesium
   module IonExporter
+    Gem.install 'aws-eventstream'
+    Gem.install 'aws-partitions'
+    Gem.install 'aws-sigv4'
+    Gem.install 'aws-sdk-core'
+    Gem.install 'aws-sdk-kms'
     Gem.install 'aws-sdk-s3'
+    Gem.install 'jmespath'
     Gem.install 'rubyzip'
 
     PLUGIN_ID = File.basename(__FILE__, ".rb")


### PR DESCRIPTION
On a fresh install we were missing some dependencies of `aws-sdk-s3`. I think they were there from an earlier dev version so I never got an error with the final version.